### PR TITLE
Use imageio instead of scipy.misc for imread

### DIFF
--- a/cromosim/comp.py
+++ b/cromosim/comp.py
@@ -5,7 +5,7 @@
 
 import sys
 import scipy as sp
-from scipy.misc import imread
+from imageio import imread
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D

--- a/cromosim/domain.py
+++ b/cromosim/domain.py
@@ -4,7 +4,7 @@
 # License: GPL
 
 import scipy as sp
-from scipy.misc import imread
+from imageio import imread
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse, Circle, Rectangle, Polygon

--- a/cromosim/micro.py
+++ b/cromosim/micro.py
@@ -5,7 +5,7 @@
 
 import sys
 import scipy as sp
-from scipy.misc import imread
+from imageio import imread
 #from scipy.spatial import KDTree
 from scipy.spatial import cKDTree
 from scipy.sparse import csr_matrix

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numpydoc >=0.7.0
 sphinx >=1.6.3
 scikit-fmm >=0.0.9
 cvxopt >= 1.2.3
+imageio >= 2.5.0


### PR DESCRIPTION
imread from scipy.misc has been deprecated since scipy 1.0 and
removed from scipy 1.2

See also https://imageio.readthedocs.io/en/stable/scipy.html